### PR TITLE
Změna inicializace TokenStorage třídy z důvodu customizace času expirace.

### DIFF
--- a/mergadoapiclient/client.py
+++ b/mergadoapiclient/client.py
@@ -2,7 +2,7 @@
 
 
 import importlib
-from datetime import datetime, timedelta
+
 try:
     from urlparse import urljoin
 except ImportError:
@@ -59,9 +59,8 @@ class BaseClient(object):
 
         self.storage = self.TokenStorage.init(
             token=resp_data['access_token'],
-            expires_at=(datetime.now() +
-                        timedelta(seconds=resp_data['expires_in'])),
-        )
+            expires_in=resp_data['expires_in'])
+
         self.storage.save()
         return self.storage.token
 

--- a/mergadoapiclient/storage.py
+++ b/mergadoapiclient/storage.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 
 
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 class BaseTokenStorage(object):
     """Token storage representation."""
 
     @classmethod
-    def init(cls, token=None, expires_at=None):
+    def init(cls, token=None, expires_in=None):
         # dedicated init because if django ORM is used, overriding
         # __init__ may prevent the model instance from being saved.
         # see https://docs.djangoproject.com/en/1.8/ref/models/instances/
         self = cls()
         self.token = token
-        self.expires_at = expires_at
+        self.expires_at = datetime.now() + timedelta(seconds=expires_in)
         return self
 
     @property


### PR DESCRIPTION
Let token storage class determine it's own expiration time (because of diffrent timezones for instance) by passing `expires_in` argument instead of `expires_at` argument to init.