### PR TITLE
Retry request option added

### DIFF
--- a/mergadoapiclient/__init__.py
+++ b/mergadoapiclient/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-__version__ = '0.1.4'
-__authors__ = ['Lukáš Ševčík', 'Peter Smatana', 'Pavel Dedík', 'Matěj Hamala']
+__version__ = '0.1.5'
+__authors__ = ['Lukáš Ševčík', 'Peter Smatana', 'Pavel Dedík', 'Matěj Hamala',
+               'Alžbeta Mazurkovičová']


### PR DESCRIPTION
### Closes: MichalJanik/mergado#7962

### Includes:
-added option for requests retrying when specified status codes are obtained from response
-status codes to trigger retry set defaultly to 500,502,503 and 504 (can be changed by spcecifying retry_status_list arg of codes when initializing client)
-number of tries defaultly set to 3 (can be changed by spcecifying tries arg when initializing client)