### PR TITLE
Fix token handling if in memory storege is used

### DIFF
--- a/mergadoapiclient/storage.py
+++ b/mergadoapiclient/storage.py
@@ -28,5 +28,8 @@ class BaseTokenStorage(object):
         """Loads storage instance. Default implementation stores the
         token in memory and does nothing else.
         """
+        if not hasattr(self, 'token'):
+            return
+
         if self.token and self.token_is_valid:
             return self


### PR DESCRIPTION
If no external storage for the token is used, the API does not work, as it attempts to fetch the token from OAuth. First, self.storage.load() is called, but the token is not yet an attribute of the storage. This fix first checks if the token attribute exists. If not, a request to OAuth will be sent, and the current token will be loaded.